### PR TITLE
feat(HW16): k8s configuration

### DIFF
--- a/hw12_13_14_15_calendar/.gitignore
+++ b/hw12_13_14_15_calendar/.gitignore
@@ -1,2 +1,3 @@
 logs/
 bin/
+build/k8s/helm/*/charts

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/.helmignore
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/Chart.lock
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.4.3
+- name: rabbitmq
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.9.0
+digest: sha256:fd86e79c289188bfac87707395ba97e6dc3f4f4589e12822f2984ac98863f84b
+generated: "2024-01-31T19:36:40.030803779+03:00"

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/Chart.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: k8-otus-calendar
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"
+
+dependencies:
+  - name: postgresql
+    version: "13.4.3"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: rabbitmq
+    version: "12.9.0"
+    repository: https://charts.bitnami.com/bitnami
+    condition: rmq.enabled

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/NOTES.txt
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "k8-otus-calendar.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "k8-otus-calendar.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "k8-otus-calendar.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "k8-otus-calendar.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/_helpers.tpl
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8-otus-calendar.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8-otus-calendar.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8-otus-calendar.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "k8-otus-calendar.labels" -}}
+helm.sh/chart: {{ include "k8-otus-calendar.chart" . }}
+{{ include "k8-otus-calendar.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8-otus-calendar.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8-otus-calendar.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "k8-otus-calendar.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "k8-otus-calendar.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/app-calendar-deployment.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/app-calendar-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "k8-otus-calendar-app"
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "k8-otus-calendar.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "k8-otus-calendar.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.app.calendarApp.name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.app.calendarApp.image.repository }}:{{ .Values.app.calendarApp.image.tag }}"
+          imagePullPolicy: {{ .Values.app.calendarApp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.httpPort }}
+              protocol: TCP
+            - name: grpc
+              containerPort: {{ .Values.service.grpcPort }}
+              protocol: TCP
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DB_HOST
+              value: "{{ .Release.Name}}-postgresql-hl"
+            - name: DB_NAME
+              value: {{ .Values.postgresql.global.postgresql.postgresqlDatabase | quote }}
+            - name: DB_PASSWORD
+              value: {{ .Values.postgresql.global.postgresql.postgresqlPassword | quote }}
+            - name: DB_USERNAME
+              value: {{ .Values.postgresql.global.postgresql.postgresqlUsername | quote }}
+            - name: DB_PORT
+              value: {{ .Values.postgresql.global.postgresql.servicePort | quote }}
+            {{- end }}
+            - name: STORAGE_MIGRATIONS_PATH
+              value: {{ .Values.app.migrationPath }}
+            - name: HTTP_HOST
+              value: 0.0.0.0
+            - name: GRPC_HOST
+              value: 0.0.0.0
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}                
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/hpa.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "k8-otus-calendar.fullname" . }}
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "k8-otus-calendar.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/ingress.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "k8-otus-calendar.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/scheduler-calendar-deployment.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/scheduler-calendar-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "k8-otus-calendar-scheduler"
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "k8-otus-calendar.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "k8-otus-calendar.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:                
+        # Scheduler
+        - name: {{ .Values.app.calendarScheduler.name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.app.calendarScheduler.image.repository }}:{{ .Values.app.calendarScheduler.image.tag }}"
+          imagePullPolicy: {{ .Values.app.calendarScheduler.image.pullPolicy }}          
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DB_HOST
+              value: "{{ .Release.Name}}-postgresql-hl"
+            - name: DB_NAME
+              value: {{ .Values.postgresql.global.postgresql.auth.database | quote }}
+            - name: DB_PASSWORD
+              value: {{ .Values.postgresql.global.postgresql.auth.password | quote }}
+            - name: DB_USERNAME
+              value: {{ .Values.postgresql.global.postgresql.auth.username | quote }}
+            - name: DB_PORT
+              value: {{ .Values.postgresql.global.postgresql.servicePort | quote }}
+            {{- end }}
+            - name: STORAGE_MIGRATIONS_PATH
+              value: {{ .Values.app.migrationPath }}
+            - name: RMQ_URI
+              value: "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name}}-rabbitmq-headless:5672/"           
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/sender-calendar-deployment.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/sender-calendar-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "k8-otus-calendar-sender"
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "k8-otus-calendar.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "k8-otus-calendar.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:                
+        # Scheduler
+        - name: {{ .Values.app.calendarSender.name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.app.calendarSender.image.repository }}:{{ .Values.app.calendarSender.image.tag }}"
+          imagePullPolicy: {{ .Values.app.calendarSender.image.pullPolicy }}          
+          env:            
+            - name: RMQ_URI
+              value: "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name}}-rabbitmq-headless:5672/"           
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/service.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8-otus-calendar.fullname" . }}
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: {{ .Values.service.httpPort }}
+      protocol: TCP
+      name: http
+    - port: 8081
+      targetPort: {{ .Values.service.grpcPort }}
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "k8-otus-calendar.selectorLabels" . | nindent 4 }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/serviceaccount.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "k8-otus-calendar.serviceAccountName" . }}
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/tests/test-connection.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "k8-otus-calendar.fullname" . }}-test-connection"
+  labels:
+    {{- include "k8-otus-calendar.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "k8-otus-calendar.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/values.yaml
+++ b/hw12_13_14_15_calendar/build/k8s/helm/k8-otus-calendar/values.yaml
@@ -1,0 +1,151 @@
+# Default values for k8-otus-calendar.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+app:
+  migrationPath: /etc/calendar/migrations
+  calendarApp:
+    name: "main-calendar-app"
+    image:
+      repository: xander88/otus-calendar-app
+      tag: "latest"
+      pullPolicy: IfNotPresent      
+  calendarScheduler:
+    name: "calendar-scheduler"
+    image:
+      repository: xander88/otus-calendar-scheduler
+      tag: "latest"
+      pullPolicy: IfNotPresent
+  calendarSender:
+    name: "calendar-sender"
+    image:
+      repository: xander88/otus-calendar-sender
+      tag: "latest"
+      pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+  httpPort: 8080
+  grpcPort: 8081
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: otus-calendar.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 20
+  periodSeconds: 10
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+postgresql:
+  enabled: true
+  global:
+    postgresql:
+      auth:
+        database: "otus-db"
+        password: "postgres"
+        username: "postgres"
+  image:
+    tag: 14
+  primary:
+    persistence:
+      enabled: false
+
+rabbitmq:
+  enabled: true
+  persistence:
+    enabled: false
+  auth:
+    username: "rmq-user"
+    password: "rmq-user"
+    erlangCookie: "some-cookie"


### PR DESCRIPTION
Добавил простейшую конфигурацию кубов. Все основные сущности реализованы (Deployment, Service, Ingress). Liveness и Readiness пробы настроены (для основного приложения). Helm используется, шаблоны генерируются. В конфигурации используются зависимости (postgres и RMQ), однако папку `/charts` с ними не пушил (вроде бы не рекомендуется).

Список всего, что есть в кластере:

![image](https://github.com/XanderKon/hw-otus/assets/16461100/5c545cc7-3eb2-483a-8588-0ffffa7c6bf0)

Проверка, как работает Ingress

![image](https://github.com/XanderKon/hw-otus/assets/16461100/212f43a3-733b-46dd-b749-06287a462aec)
